### PR TITLE
Fixes #22 path d attribute for arcs should not use autocad like parametrisation

### DIFF
--- a/Da/DAttribute.cs
+++ b/Da/DAttribute.cs
@@ -50,27 +50,32 @@ namespace SvgElements.Da {
 		}
 
 
-		public void AddMoveAndArc(double cx, double cy, double sa, double ea, double r, bool counterClockWise = true) {
-			_daList.Add(new MoveAbsArcDaClause(cx, cy, sa, ea, r, counterClockWise));
+		public void AddMoveAndArc(double startX, double startY, double endX, double endY, double r, bool largeArc, bool sweep) {
+			_daList.Add(new MoveAbsArcDaClause(startX, startY, endX, endY, r, largeArc, sweep));
 		}
 
 
-		public void AddMoveAndArc(double cx, double cy, double sa, double ea, double rx, double ry, double rot, bool counterClockWise = true) {
-			_daList.Add(new MoveAbsArcDaClause(cx, cy, sa, ea, rx, ry, rot, counterClockWise));
+		public void AddMoveAndArc(double startX, double startY, double endX, double endY, double rx, double ry, double rot, bool largeArc, bool sweep) {
+			_daList.Add(new MoveAbsArcDaClause(startX, startY, endX, endY, rx, ry, rot, largeArc, sweep));
 		}
 
 
-		public void AddLineAndArc(double cx, double cy, double sa, double ea, double r, bool counterClockWise = true) {
-			_daList.Add(new LineAbsArcDaClause(cx, cy, sa, ea, r, counterClockWise));
+		public void AddLineAndArc(double startX, double startY, double endX, double endY, double r, bool largeArc, bool sweep) {
+			_daList.Add(new LineAbsArcDaClause(startX, startY, endX, endY, r, largeArc, sweep));
 		}
 
 
-        internal void AddArc(double r1, double r2, double rot, bool lf, bool sf, double xe, double ye) {
-			_daList.Add(new ArcDaClause(r1, r2, rot, lf, sf, xe, ye));
+        public void AddLineAndArc(double startX, double startY, double endX, double endY, double rx, double ry, double rot, bool largeArc, bool sweep) {
+            _daList.Add(new LineAbsArcDaClause(startX, startY, endX, endY, rx, ry, rot, largeArc, sweep));
         }
 
 
-        internal void AddMoveAndQSpline(double[] doubles) {
+        public void AddArc(double r1, double r2, double rot, bool largeArc, bool sweep, double xe, double ye) {
+			_daList.Add(new ArcDaClause(r1, r2, rot, largeArc, sweep, xe, ye));
+        }
+
+
+        public void AddMoveAndQSpline(double[] doubles) {
             _daList.Add(new QSplineDaClause(doubles[0], doubles[1], doubles[2], doubles[3], doubles[4], doubles[5]));
         }
 

--- a/Da/DAttribute.cs
+++ b/Da/DAttribute.cs
@@ -80,7 +80,7 @@ namespace SvgElements.Da {
         }
 
 
-        internal void AddMoveAndCSpline(double[] doubles) {
+        public void AddMoveAndCSpline(double[] doubles) {
             _daList.Add(new CSplineDaClause(doubles[0], doubles[1], doubles[2], doubles[3], doubles[4], doubles[5], doubles[6], doubles[7]));
         }
 

--- a/Da/DaAbsArcClauseBase.cs
+++ b/Da/DaAbsArcClauseBase.cs
@@ -1,0 +1,74 @@
+﻿#region copyright LGPL nanoLogika
+//  Copyright 2023, nanoLogika GmbH.
+//  All rights reserved. 
+//  This source code is licensed under the "LGPL v3 or any later version" license. 
+//  See LICENSE file in the project root for full license information.
+#endregion
+
+namespace SvgElements.Da {
+
+    internal class DaAbsArcClauseBase : DaClauseBase {
+
+        public DaAbsArcClauseBase(double startX, double startY, double endX, double endY, double r, bool largeArc, bool sweep, string letter)
+            : base(letter) {
+
+            StartX = startX;
+            StartY = startY;
+            EndX = endX;
+            EndY = endY;
+            Rx = r;
+            Ry = r;
+            Rot = 0;
+            Lf = largeArc ? 1 : 0;
+            Sf = sweep ? 1 : 0;
+        }
+
+
+        public DaAbsArcClauseBase(double startX, double startY, double endX, double endY, double rx, double ry, double rot, bool largeArc, bool sweep, string letter)
+            : base(letter) {
+
+            StartX = startX;
+            StartY = startY;
+            EndX = endX;
+            EndY = endY;
+            Rx = rx;
+            Ry = ry;
+            Rot = rot;
+            Lf = largeArc ? 1 : 0;
+            Sf = sweep ? 1 : 0;
+        }
+
+
+        public double StartX { get; }
+
+
+        public double StartY { get; }
+
+
+        public double Rx { get; set; }
+
+
+        public double Ry { get; set; }
+
+
+        public double Rot { get; set; }
+
+
+        public double Lf { get; }
+
+
+        public double Sf { get; }
+
+
+        public double EndX { get; }
+
+
+        public double EndY { get; }
+
+
+        public override string ToString() {
+            return $"{base.ToString()} {Cd(StartX)} {Cd(StartY)} A {Cd(Rx)} {Cd(Ry)} {Cd(Rot)} {Lf} {Sf} {Cd(EndX)} {Cd(EndY)}";
+        }
+
+    }
+}

--- a/Da/LineAbsArcDaClause.cs
+++ b/Da/LineAbsArcDaClause.cs
@@ -7,48 +7,15 @@
 
 namespace SvgElements.Da {
 
-	internal class LineAbsArcDaClause : DaClauseBase {
+	internal class LineAbsArcDaClause : DaAbsArcClauseBase {
 
-		public double Mx { get; }
-
-
-		public double My { get; }
-
-
-		public double R { get; }
-
-
-		public double Lf { get; }
-
-
-		public double Sf { get; }
-
-
-		public double Ex { get; }
-
-
-		public double Ey { get; }
-
-
-		public LineAbsArcDaClause(double cx, double cy, double sa, double ea, double r, bool counterClockWise = true) : base("L") {
-			var f = counterClockWise ? 1 : -1;
-			Sf = counterClockWise ? 1 : 0;
-			Mx = cx + r * Math.Cos(sa);
-			My = cy + r * f * Math.Sin(sa);
-			Ex = cx + r * Math.Cos(ea);
-			Ey = cy + r * f * Math.Sin(ea);
-
-			R = r;
-
-			Lf = counterClockWise && (ea - sa) < Math.PI ||
-				!counterClockWise && (ea - sa) < Math.PI
-				?
-				0 : 1;
+		public LineAbsArcDaClause(double startX, double startY, double endX, double endY, double r, bool largeArc, bool sweep)
+            : base(startX, startY, endX, endY, r, largeArc, sweep, "L") {
 		}
 
 
-		public override string ToString() {
-			return $"{base.ToString()} {Cd(Mx)} {Cd(My)} A {Cd(R)} {Cd(R)} 0 {Lf} {Sf} {Cd(Ex)} {Cd(Ey)}";
-		}
+        public LineAbsArcDaClause(double startX, double startY, double endX, double endY, double rx, double ry, double rot, bool largeArc, bool sweep)
+            : base(startX, startY, endX, endY, rx, ry, rot, largeArc, sweep, "L") {
+        }
 	}
 }

--- a/Da/MoveAbsArcDaClause.cs
+++ b/Da/MoveAbsArcDaClause.cs
@@ -7,75 +7,15 @@
 
 namespace SvgElements.Da {
 
-	internal class MoveAbsArcDaClause : DaClauseBase {
+	internal class MoveAbsArcDaClause : DaAbsArcClauseBase {
 
-		public double Mx { get; }
-
-
-		public double My { get; }
-
-
-		public double Rx { get; set; }
-
-
-		public double Ry { get; set; }
-
-
-		public double Rot { get; set; }
-
-
-		public double Lf { get; set; }
-
-
-		public double Sf { get; set; }
-
-
-		public double Ex { get; set; }
-
-
-		public double Ey { get; set; }
-
-
-		public MoveAbsArcDaClause(double cx, double cy, double sa, double ea, double r, bool counterClockWise = true)  : base("M") {
-			var f = counterClockWise ? 1 : -1;
-			Sf = counterClockWise ? 1 : 0;
-			Mx = cx + r * Math.Cos(sa);
-			My = cy + r * f * Math.Sin(sa);
-			Ex = cx + r * Math.Cos(ea);
-			Ey = cy + r * f * Math.Sin(ea);
-
-			Rx = r;
-			Ry = r;
-			Rot = 0;
-
-			Lf = counterClockWise && (ea - sa) < Math.PI ||
-				!counterClockWise && (ea - sa) < Math.PI
-				?
-				0 : 1;
+		public MoveAbsArcDaClause(double startX, double startY, double endX, double endY, double r, bool largeArc, bool sweep)
+			: base(startX, startY, endX, endY, r, largeArc, sweep, "M") {
 		}
 
 
-		public MoveAbsArcDaClause(double cx, double cy, double sa, double ea, double rx, double ry, double rot, bool counterClockWise = true) : base("M") {
-			var f = counterClockWise ? 1 : -1;
-			Sf = counterClockWise ? 1 : 0;
-			Mx = cx + rx * Math.Cos(rot) * Math.Cos(sa) - ry * Math.Sin(rot) * Math.Sin(sa);
-			My = cy + rx * Math.Sin(rot) * Math.Cos(sa) + ry * Math.Cos(rot) * Math.Sin(sa);
-			Ex = cx + rx * Math.Cos(rot) * Math.Cos(ea) - ry * Math.Sin(rot) * Math.Sin(ea);
-			Ey = cy + rx * Math.Sin(rot) * Math.Cos(ea) + ry * Math.Cos(rot) * Math.Sin(ea);
-
-			Rx = rx;
-			Ry = ry;
-			Rot = rot / Math.PI * 180;
-
-			Lf = counterClockWise && (ea - sa) < Math.PI ||
-				!counterClockWise && (ea - sa) < Math.PI
-				?
-				0 : 1;
-		}
-
-
-		public override string ToString() {
-			return $"{base.ToString()} {Cd(Mx)} {Cd(My)} A {Cd(Rx)} {Cd(Ry)} {Cd(Rot)} {Lf} {Sf} {Cd(Ex)} {Cd(Ey)}";
-		}
+        public MoveAbsArcDaClause(double startX, double startY, double endX, double endY, double rx, double ry, double rot, bool largeArc, bool sweep)
+			: base(startX, startY, endX, endY, rx, ry, rot, largeArc, sweep, "M") {
+        }
 	}
 }

--- a/PathElement.cs
+++ b/PathElement.cs
@@ -131,54 +131,77 @@ namespace SvgElements {
 
 
         /// <summary>
-        /// Adds a move clause and an circular arc clause to the d-Attribute
+        /// Adds move clause to the start point and an circular arc clause to the d-Attribute
         /// of this path element and returns this element.
         /// </summary>
-        /// <param name="cx"></param> 
-        /// <param name="cy"></param>
-        /// <param name="sa"></param>
-        /// <param name="ea"></param>
-        /// <param name="r"></param>
-        /// <param name="counterClockWise"></param>
+        /// <param name="startX">X of the start point of the arc.</param>
+        /// <param name="startY">Y of the start point of the arc.</param>
+        /// <param name="endX">X of the end point of the arc.</param>
+        /// <param name="endY">Y of the end point of the arc.</param>
+        /// <param name="r">The arc radius.</param>
+        /// <param name="largeArc">Indicates if <c>true</c> that the large-arc flag ist set to 1; otherwise, 0.</param>
+        /// <param name="sweep">Intcates if <c>true</c> that the sweep flag is set to 1; otherwise, 0.</param>
         /// <returns>This <see cref="PathElement"/>.</returns>
-        public PathElement AddMoveAndArc(double cx, double cy, double sa, double ea, double r, bool counterClockWise = true) {
-            _da.AddMoveAndArc(cx, cy, sa, ea, r, counterClockWise);
+        public PathElement AddMoveAndArc(double startX, double startY, double endX, double endY, double r, bool largeArc, bool sweep) {
+            _da.AddMoveAndArc(startX, startY, endX, endY, r, largeArc, sweep);
             return this;
         }
 
 
         /// <summary>
-        /// Adds a move clause and an elliptic arc clause to the d-Attribute
+        /// Adds a move clause to the start point and an elliptic arc clause to the d-Attribute
         /// of this path element and returns this element.
         /// </summary>
-        /// <param name="cx"></param>
-        /// <param name="cy"></param>
-        /// <param name="sa"></param>
-        /// <param name="ea"></param>
-        /// <param name="rx"></param>
-        /// <param name="ry"></param>
-        /// <param name="rot"></param>
-        /// <param name="counterClockWise"></param>
+        /// <param name="startX">X of the start point of the arc.</param>
+        /// <param name="startY">Y of the start point of the arc.</param>
+        /// <param name="endX">X of the end point of the arc.</param>
+        /// <param name="endY">Y of the end point of the arc.</param>
+        /// <param name="rx">The length of the major axis of the ellipse.</param>
+        /// <param name="ry">The length of the minor axis of the ellipse.</param>
+        /// <param name="rot">The rotation of the major axis in degrees.</param>
+        /// <param name="largeArc">Indicates if <c>true</c> that the large-arc flag ist set to 1; otherwise, 0.</param>
+        /// <param name="sweep">Intcates if <c>true</c> that the sweep flag is set to 1; otherwise, 0.</param>
         /// <returns>This <see cref="PathElement"/>.</returns>
-        public PathElement AddMoveAndArc(double cx, double cy, double sa, double ea, double rx, double ry, double rot, bool counterClockWise = true) {
-            _da.AddMoveAndArc(cx, cy, sa, ea, rx, ry, rot, counterClockWise);
+        public PathElement AddMoveAndArc(double startX, double startY, double endX, double endY, double rx, double ry, double rot, bool largeArc, bool sweep) {
+            _da.AddMoveAndArc(startX, startY, endX, endY, rx, ry, rot, largeArc, sweep);
             return this;
         }
 
 
         /// <summary>
-        /// Adds a line clause and an arc clause to the d-Attribute
+        /// Adds a line clause to the start point and an arc clause to the d-Attribute
         /// of this path element and returns this element.
         /// </summary>
-        /// <param name="cx"></param> 
-        /// <param name="cy"></param>
-        /// <param name="sa"></param>
-        /// <param name="ea"></param>
-        /// <param name="r"></param>
-        /// <param name="counterClockWise"></param>
+        /// <param name="startX">X of the start point of the arc.</param>
+        /// <param name="startY">Y of the start point of the arc.</param>
+        /// <param name="endX">X of the end point of the arc.</param>
+        /// <param name="endY">Y of the end point of the arc.</param>
+        /// <param name="r">The arc radius.</param>
+        /// <param name="largeArc">Indicates if <c>true</c> that the large-arc flag ist set to 1; otherwise, 0.</param>
+        /// <param name="sweep">Intcates if <c>true</c> that the sweep flag is set to 1; otherwise, 0.</param>
         /// <returns>This <see cref="PathElement"/>.</returns>
-        public PathElement AddLineAndArc(double cx, double cy, double sa, double ea, double r, bool counterClockWise = true) {
-            _da.AddLineAndArc(cx, cy, sa, ea, r, counterClockWise);
+        public PathElement AddLineAndArc(double startX, double startY, double endX, double endY, double r, bool largeArc, bool sweep) {
+            _da.AddLineAndArc(startX, startY, endX, endY, r, largeArc, sweep);
+            return this;
+        }
+
+
+        /// <summary>
+        /// Adds a line clause to the start point and an elliptic arc clause to the d-Attribute
+        /// of this path element and returns this element.
+        /// </summary>
+        /// <param name="startX">X of the start point of the arc.</param>
+        /// <param name="startY">Y of the start point of the arc.</param>
+        /// <param name="endX">X of the end point of the arc.</param>
+        /// <param name="endY">Y of the end point of the arc.</param>
+        /// <param name="rx">The length of the major axis of the ellipse.</param>
+        /// <param name="ry">The length of the minor axis of the ellipse.</param>
+        /// <param name="rot">The rotation of the major axis in degrees.</param>
+        /// <param name="largeArc">Indicates if <c>true</c> that the large-arc flag ist set to 1; otherwise, 0.</param>
+        /// <param name="sweep">Intcates if <c>true</c> that the sweep flag is set to 1; otherwise, 0.</param>
+        /// <returns>This <see cref="PathElement"/>.</returns>
+        public PathElement AddLineAndArc(double startX, double startY, double endX, double endY, double rx, double ry, double rot, bool largeArc, bool sweep) {
+            _da.AddLineAndArc(startX, startY, endX, endY, rx, ry, rot, largeArc, sweep);
             return this;
         }
 


### PR DESCRIPTION
d-Attribute methods
(1) Take SVG-like parameters, e.g. (elliptic arc)
* AddMoveAndArc(double startX, double startY, double endX, double endY, double rx, double ry, double rot, bool largeArc, bool sweep)
* AddLineAndArc(double startX, double startY, double endX, double endY, double rx, double ry, double rot, bool largeArc, bool sweep)
(2) All methods public.

Arc clause
* new class DaAbsArcClauseBase defines arc-clause properties and ToString()
* derived MoveAbsArcDaClause, LineAbsArcDaClause

PathElement
* Methods with SVG-like parameters